### PR TITLE
feat(calendar): implement service to group user files and folders by …

### DIFF
--- a/controllers/calendarController.js
+++ b/controllers/calendarController.js
@@ -1,0 +1,16 @@
+const createError = require('http-errors');
+const calendarService = require('../services/calendarService');
+
+async function getCalendarView(req, res, next) {
+  try {
+    const userId = req.user._id;
+        console.log('Fetching calendar items for user:', userId);
+
+    const data = await calendarService.getItemsGroupedByDate(userId);
+    res.status(200).json({ success: true, data });
+  } catch (err) {
+    next(createError(500, 'Failed to fetch calendar items'));
+  }
+}
+
+module.exports = { getCalendarView };

--- a/models/StorageFile.js
+++ b/models/StorageFile.js
@@ -1,6 +1,5 @@
 const mongoose = require('mongoose');
 const People = require('./People');
-// const Folder = require('./folderUpload');
 
 const storageFileSchema = new mongoose.Schema({
   userId: {

--- a/routes/calendar/calendarRoutes.js
+++ b/routes/calendar/calendarRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const authMiddleware = require('../../middlewares/users/authMiddleware');
+const { getCalendarView } = require('../../controllers/calendarController');
+
+router.get('/items', authMiddleware, getCalendarView);
+
+module.exports = router;

--- a/routes/route.js
+++ b/routes/route.js
@@ -1,4 +1,5 @@
 const express = require('express');
+
 const router = express.Router();
 
 // Auth routes
@@ -9,6 +10,8 @@ const folderRoutes = require('./storage/folderRoutes');
 const infoRoutes = require('./storage/infoRoutes');
 const fileRoutes = require('./storage/fileRoutes');
 const fileOpsRoutes = require('./storage/fileOpsRoutes');
+// calendar routes
+const calendarRoutes = require('./calendar/calendarRoutes');
 // Mount under /v1/auth
 router.use('/v1/auth', localRoutes);
 router.use('/v1/auth', googleRoutes);
@@ -16,5 +19,7 @@ router.use('/v1/auth', googleRoutes);
 router.use('/v1/storage', fileRoutes);
 router.use('/v1/storage', folderRoutes);
 router.use('/v1/storage', infoRoutes);
-router.use('/v1/storage',fileOpsRoutes);
+router.use('/v1/storage', fileOpsRoutes);
+// Mount under/v1/calendar
+router.use('/v1/calendar', calendarRoutes);
 module.exports = router;

--- a/services/calendarService.js
+++ b/services/calendarService.js
@@ -1,0 +1,46 @@
+const StorageFile = require('../models/StorageFile');
+const Folder = require('../models/Folder');
+
+async function getItemsGroupedByDate(userId) {
+  const [files, folders] = await Promise.all([
+    StorageFile.find({ userId }),
+    Folder.find({ userId }),
+  ]);
+
+  console.log("📁 Fetched files:", files.length);
+  console.log("📂 Fetched folders:", folders.length);
+
+  const combinedItems = [
+    ...files.map((file) => ({
+      _id: file._id,
+      name: file.fileName,
+      type: 'file',
+      date: file.uploadDate,
+    })),
+    ...folders.map((folder) => ({
+      _id: folder._id,
+      name: folder.folderName,
+      type: 'folder',
+      date: folder.createdAt,
+    })),
+  ];
+
+  const grouped = {};
+
+  combinedItems.forEach((item) => {
+    const dateKey = item.date.toISOString().split('T')[0]; // format YYYY-MM-DD
+    if (!grouped[dateKey]) {
+      grouped[dateKey] = [];
+    }
+    grouped[dateKey].push(item);
+  });
+
+  // Return groups in descending date order
+  return Object.fromEntries(
+    Object.entries(grouped).sort((a, b) => new Date(b[0]) - new Date(a[0]))
+  );
+}
+
+module.exports = {
+  getItemsGroupedByDate,
+};


### PR DESCRIPTION
This PR introduces a new calendar view feature that fetches all user-uploaded files and folders grouped by their upload date. The changes include:

-A dedicated service to group items by createdAt field.

-A new controller endpoint under /api/v1/calendar/items.

-Integration with both StorageFile and Folder models.

-Logs to assist with debugging item grouping logic.